### PR TITLE
Fix imports in order for code to work with React Native >= 0.40

### DIFF
--- a/ios/RCTWebViewBridge.h
+++ b/ios/RCTWebViewBridge.h
@@ -10,7 +10,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTView.h"
+#import <React/RCTView.h>
 
 @class RCTWebViewBridge;
 

--- a/ios/RCTWebViewBridge.m
+++ b/ios/RCTWebViewBridge.m
@@ -14,13 +14,13 @@
 
 #import <UIKit/UIKit.h>
 
-#import "RCTAutoInsetsProtocol.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
-#import "RCTLog.h"
-#import "RCTUtils.h"
-#import "RCTView.h"
-#import "UIView+React.h"
+#import <React/RCTAutoInsetsProtocol.h>
+#import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTLog.h>
+#import <React/RCTUtils.h>
+#import <React/RCTView.h>
+#import <React/UIView+React.h>
 #import <objc/runtime.h>
 
 //This is a very elegent way of defining multiline string in objective-c.
@@ -334,7 +334,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   return [NSString stringWithContentsOfFile:webViewBridgeScriptFile
                                                                     encoding:NSUTF8StringEncoding
                                                                        error:nil];
-    
+
 }
 
 @end

--- a/ios/RCTWebViewBridgeManager.h
+++ b/ios/RCTWebViewBridgeManager.h
@@ -10,7 +10,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface RCTWebViewBridgeManager : RCTViewManager
 

--- a/ios/RCTWebViewBridgeManager.m
+++ b/ios/RCTWebViewBridgeManager.m
@@ -12,10 +12,10 @@
 
 #import "RCTWebViewBridgeManager.h"
 
-#import "RCTBridge.h"
-#import "RCTUIManager.h"
+#import <React/RCTBridge.h>
+#import <React/RCTUIManager.h>
 #import "RCTWebViewBridge.h"
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 
 @interface RCTWebViewBridgeManager () <RCTWebViewBridgeDelegate>
 


### PR DESCRIPTION
This PR fixed imports to reflect the breaking changes introduced in React 0.40, so we can bump the version from 0.39 without running into problems.